### PR TITLE
Add pip install continuo workflow

### DIFF
--- a/.github/workflows/pip-test.yml
+++ b/.github/workflows/pip-test.yml
@@ -1,0 +1,24 @@
+name: Check pip install
+
+on: [push]
+
+env:
+  PACKAGE_NAME: continuo
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Install pypi package
+        run: |
+          python -m pip install --upgrade pip
+          pip install $PACKAGE_NAME
+          python -m $PACKAGE_NAME -h

--- a/.github/workflows/pip-test.yml
+++ b/.github/workflows/pip-test.yml
@@ -20,5 +20,6 @@ jobs:
       - name: Install pypi package
         run: |
           python -m pip install --upgrade pip
+          pip install setuptools
           pip install $PACKAGE_NAME
           python -m $PACKAGE_NAME -h

--- a/.github/workflows/pip-test.yml
+++ b/.github/workflows/pip-test.yml
@@ -1,6 +1,9 @@
 name: Check pip install
 
-on: [push]
+on:
+  workflow_run:
+    workflows: ['Upload Python Package']
+    types: [completed]
 
 env:
   PACKAGE_NAME: continuo
@@ -13,10 +16,10 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
-          python-version: "3.x"
+          python-version: ${{ matrix.python-version }}
       - name: Install pypi package
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
Added workflow testing `pip install continuo & python -m continuo -h` as a form of pip install smoke test to be run after every pypi publish.